### PR TITLE
Add devopsdays tokyo 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@
 
 - [Go Conference mini 2023 Winter IN KYOTO](https://kyotogo.connpass.com/event/285351/)
   - [GoのProtocプラグインを活用した効率的な負荷試験戦略 / Efficient Load Testing Strategies Utilizing the Go Protoc Plugin - Speaker Deck](https://speakerdeck.com/biwashi/efficient-load-testing-strategies-utilizing-the-go-protoc-plugin)
-
+- [devopsdays Tokyo 2024](https://devopsdays.org/events/2024-tokyo/welcome/)
+  - [DevOpsDays Tokyo 2024 - Program Schedule | ConfEngine - Conference Platform](https://confengine.com/conferences/devopsdays-tokyo-2024/schedule/rich)
+  - [自動生成を活用した、運用保守コストを抑える Error/Alert/Runbook の一元集約管理 / Centralized management of Error/Alert/Runbook to minimize operational costs using automated code generation - Speaker Deck](https://speakerdeck.com/biwashi/runbook-to-minimize-operational-costs-using-automated-code-generation)
 
 # ブログ
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,10 @@
 ## 言語
 
 - Go
-  - 2 年程度
+  - 3 年程度
   - Web サービスのバックエンド
+  - CLI ツールの作成
+  - 自動生成ツールの作成
 - Python
   - 3 年程度
   - ハッカソンでの Web サービスのバックエンド
@@ -145,7 +147,7 @@
 
 ## インフラ
 - AWS
-  - 2 年程度
+  - 3 年程度
   - ECS on Fargate, Aurora 等を使用した基本的な構成のシステム構築経験
 - GCP
   - 1 年程度
@@ -154,13 +156,13 @@
 ## ツール
 
 - Datadog
-  - 1 年程度
+  - 2 年程度
   - ECS on Fargate への Sidecar での Agent 構築経験
   - APM, Continuous Profiler, Logs, Monitors の構築
+  - Mobile App Testing を用いたモバイル端末の自動テスト
 - Terraform
-  - 2 年程度
-  - AWS, GCP での基本的な実装
-  - CloudCDN を用いた署名付き URL の実装
+  - 3 年程度
+  - AWS, GCP での使用
 - Raspberry pi
   - 3 年
   - 大学・大学院での研究に使用

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,8 +126,10 @@
 ## 言語
 
 - Go
-  - 2 年程度
+  - 3 年程度
   - Web サービスのバックエンド
+  - CLI ツールの作成
+  - 自動生成ツールの作成
 - Python
   - 3 年程度
   - ハッカソンでの Web サービスのバックエンド
@@ -145,7 +147,7 @@
 
 ## インフラ
 - AWS
-  - 2 年程度
+  - 3 年程度
   - ECS on Fargate, Aurora 等を使用した基本的な構成のシステム構築経験
 - GCP
   - 1 年程度
@@ -154,13 +156,13 @@
 ## ツール
 
 - Datadog
-  - 1 年程度
+  - 2 年程度
   - ECS on Fargate への Sidecar での Agent 構築経験
   - APM, Continuous Profiler, Logs, Monitors の構築
+  - Mobile App Testing を用いたモバイル端末の自動テスト
 - Terraform
-  - 2 年程度
-  - AWS, GCP での基本的な実装
-  - CloudCDN を用いた署名付き URL の実装
+  - 3 年程度
+  - AWS, GCP での使用
 - Raspberry pi
   - 3 年
   - 大学・大学院での研究に使用
@@ -172,7 +174,9 @@
 
 - [Go Conference mini 2023 Winter IN KYOTO](https://kyotogo.connpass.com/event/285351/)
   - [GoのProtocプラグインを活用した効率的な負荷試験戦略 / Efficient Load Testing Strategies Utilizing the Go Protoc Plugin - Speaker Deck](https://speakerdeck.com/biwashi/efficient-load-testing-strategies-utilizing-the-go-protoc-plugin)
-
+- [devopsdays Tokyo 2024](https://devopsdays.org/events/2024-tokyo/welcome/)
+  - [DevOpsDays Tokyo 2024 - Program Schedule | ConfEngine - Conference Platform](https://confengine.com/conferences/devopsdays-tokyo-2024/schedule/rich)
+  - [自動生成を活用した、運用保守コストを抑える Error/Alert/Runbook の一元集約管理 / Centralized management of Error/Alert/Runbook to minimize operational costs using automated code generation - Speaker Deck](https://speakerdeck.com/biwashi/runbook-to-minimize-operational-costs-using-automated-code-generation)
 
 # ブログ
 


### PR DESCRIPTION
This pull request primarily updates the `README.md` and `docs/README.md` files. The changes mainly revolve around updating the years of experience in different languages, tools, and infrastructures. Additionally, there are updates to the list of conferences attended and presentations given. 

Experience Updates:

* `README.md` and `docs/README.md`: Updated years of experience with Go from 2 to 3 years, and added experience in creating CLI tools and auto-generation tools.
* `README.md` and `docs/README.md`: Updated years of experience with AWS from 2 to 3 years.
* `README.md` and `docs/README.md`: Updated years of experience with Datadog from 1 to 2 years, and added experience in Mobile App Testing. Also, updated years of experience with Terraform from 2 to 3 years, and removed specific implementation details.

Conference Updates:

* `README.md` and `docs/README.md`: Added attendance and presentation at devopsdays Tokyo 2024.