### PR TITLE
Update resume with recent public speaking engagements

### DIFF
--- a/components/resume.tsx
+++ b/components/resume.tsx
@@ -146,6 +146,14 @@ export function Resume() {
               <h2 className="text-2xl font-bold mb-4 border-b-2 border-gray-300">Public Speaking</h2>
               <ul className="space-y-4">
                 <li>
+                  <h3 className="font-semibold">Top 4 Load Testing Tools! User Insights into Effective Performance Testing Practices (September 2024)</h3>
+                  <p>Topic: &quot;Building a Scalable and Reproducible Load Testing Platform with k6&quot;</p>
+                </li>
+                <li>
+                  <h3 className="font-semibold">Learn from Real-World Use Cases! The Unknown World of Datadog (August 2024)</h3>
+                  <p>Topic: &quot;Advanced techniques for leveraging Datadog&apos;s features&quot;</p>
+                </li>
+                <li>
                   <h3 className="font-semibold">OpenTelemetry Meetup #3 (June 2024)</h3>
                   <p>Topic: &quot;Feature Flags and OpenTelemetry&quot;</p>
                 </li>


### PR DESCRIPTION
This pull request adds new entries to the "Public Speaking" section in the `Resume` component. The change includes two new public speaking events with their respective titles and topics.

Changes in `components/resume.tsx`:

* Added a new public speaking event titled "Top 4 Load Testing Tools! User Insights into Effective Performance Testing Practices (September 2024)" with the topic "Building a Scalable and Reproducible Load Testing Platform with k6". (`components/resume.tsx`)
* Added another new public speaking event titled "Learn from Real-World Use Cases! The Unknown World of Datadog (August 2024)" with the topic "Advanced techniques for leveraging Datadog's features". (`components/resume.tsx`)