### PR TITLE
fix: remove next.config.js that overrides static export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-  swcMinify: true,
-  output: 'standalone',
-}
-
-module.exports = nextConfig


### PR DESCRIPTION
## 原因
`next.config.js` (output: standalone) と `next.config.mjs` (output: export) が両方存在していて、`.js` が優先されていた。

そのため `out/` ディレクトリが生成されず、GitHub Pages の `upload-pages-artifact` が失敗していた。

## 修正
`next.config.js` を削除。`next.config.mjs` のみに統一。

## 確認
ローカルで `GITHUB_PAGES=true npm run build` → `out/` 正常生成を確認済み。