### PR TITLE
fix: add basePath prefix to image src for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
       - run: npm run build
         env:
           GITHUB_PAGES: "true"
+          NEXT_PUBLIC_BASE_PATH: "/resume"
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./out

--- a/components/resume.tsx
+++ b/components/resume.tsx
@@ -3,6 +3,8 @@
 import Image from 'next/image'
 import { Mail, MapPin, Linkedin, Github, Presentation } from 'lucide-react'
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
+
 export function Resume() {
   return (
     <div className="min-h-screen bg-white py-12 px-4 sm:px-6 lg:px-8">
@@ -13,7 +15,7 @@ export function Resume() {
             <div className="flex flex-col items-center mb-6">
               <div className="w-48 h-48 relative overflow-hidden rounded-full mb-4">
                 <Image
-                  src="/images/shota_iwami.jpeg"
+                  src={`${basePath}/images/shota_iwami.jpeg`}
                   alt="Shota Iwami"
                   width={200}
                   height={200}

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-  swcMinify: true,
-  output: 'standalone',
-}
-
-module.exports = nextConfig

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,9 @@
 /** @type {import('next').NextConfig} */
+const basePath = process.env.GITHUB_PAGES === "true" ? "/resume" : "";
 const nextConfig = {
   output: "export",
-  basePath: process.env.GITHUB_PAGES === "true" ? "/resume" : "",
+  basePath,
+  assetPrefix: basePath,
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## 問題
`next/image` は静的エクスポート時に `basePath` を `src` に付与しない。GitHub Pagesで画像が表示されなかった。

## 修正
- `NEXT_PUBLIC_BASE_PATH` 環境変数で画像パスにプレフィックス付与
- GitHub Actions workflowにも環境変数追加
- `assetPrefix` 設定追加